### PR TITLE
Hashing

### DIFF
--- a/src/SPDX.jl
+++ b/src/SPDX.jl
@@ -29,6 +29,9 @@ include("readJSON.jl")
 include("readTagValue.jl")
 include("checksums.jl")
 include("api.jl")
-include("../test/build_testDocument.jl")  # This is our precompilation
+
+# Precompilation
+include("../test/build_testDocument.jl")
+h= hash(a)
 
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -129,3 +129,10 @@ for pred in (:(==), :(isequal))
         return all(f -> $pred(getproperty(x, f), getproperty(y, f)), fieldnames(typeof(x)))
     end
 end
+
+function Base.hash(A::AbstractSpdx, h::UInt)
+    for p in propertynames(A)
+        h= hash(p, h)
+    end
+    return h
+end

--- a/src/api.jl
+++ b/src/api.jl
@@ -132,7 +132,7 @@ end
 
 function Base.hash(A::AbstractSpdx, h::UInt)
     for p in propertynames(A)
-        h= hash(p, h)
+        h= hash(getproperty(A, p), h)
     end
     return h
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -130,9 +130,14 @@ for pred in (:(==), :(isequal))
     end
 end
 
-function Base.hash(A::AbstractSpdx, h::UInt)
-    for p in propertynames(A)
+function _hash(A::AbstractSpdx, h::UInt, skipproperties::Vector{Symbol}= Symbol[])
+    propset= setdiff(propertynames(A), skipproperties)
+    for p in propset
         h= hash(getproperty(A, p), h)
     end
     return h
+end
+
+function Base.hash(A::AbstractSpdx, h::UInt)
+    return _hash(A, h)
 end

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -21,12 +21,19 @@
     end
 
     @testset "compare" begin
+        @test  SPDX.compare_b(mysbom, mysbom2)
         @test !SPDX.compare_b(mysbom, mysbom3)
     end
 
     @testset "hash" begin
         @test hash(mysbom) == hash(mysbom2)
         @test hash(mysbom) !== hash(mysbom3)
+
+        r1= mysbom.Relationships
+        r2= mysbom2.Relationships[end:-1:1]
+        @test !all(r1 .== r2)
+        @test issetequal(r1, r2)
+        @test allunique(r1)
     end
 end
 

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -23,6 +23,11 @@
     @testset "compare" begin
         @test !SPDX.compare_b(mysbom, mysbom3)
     end
+
+    @testset "hash" begin
+        @test hash(mysbom) == hash(mysbom2)
+        @test hash(mysbom) !== hash(mysbom3)
+    end
 end
 
 @testset "Helper API" begin


### PR DESCRIPTION
Resolves #38 - Enable Set and Dict operations with SPDX data types

Created a custom `hash` function for AbstractSpdx data types. Got the hooks in so that the hash could be used in the future with SPDX analysis functions. 