### PR TITLE
Add compat for DataStructures 0.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
-DataStructures = "0.18"
+DataStructures = "0.18, 0.19"
 JSON = "0.21"
 TimeZones = "1"
 julia = "1.8"

--- a/test/test_checksums.jl
+++ b/test/test_checksums.jl
@@ -5,10 +5,11 @@
 
     checksum= ComputeFileChecksum("SHA256", joinpath(pkgdir(SPDX), "Project.toml"))
     @test checksum isa SpdxChecksumV2
-    @test checksum.Hash == open(joinpath(pkgdir(SPDX), "Project.toml")) do f 
+    @test checksum.Hash == open(joinpath(pkgdir(SPDX), "Project.toml")) do f
                                 return bytes2hex(sha256(f))
                             end
-    
+
     linktest_code= ComputePackageVerificationCode(joinpath(pkgdir(SPDX), "test", "test_package"))
-    @test issetequal(linktest_code.ExcludedFiles, ["dir_link", "file_link", "src/bad_link"])
+    @show linktest_code.ExcludedFiles
+    @test issetequal(linktest_code.ExcludedFiles, ["dir_link", "file_link", normpath("src/bad_link")])
 end


### PR DESCRIPTION
It doesn't look like this package is affected by any of the breaking changes:
https://github.com/JuliaCollections/DataStructures.jl/releases/tag/v0.19.0

Unrelated, but to fix the tests on Windows I wrapped "src/bad_link" with `normpath` to get "src\\bad_link" on Windows.

This is also drops some indirect dependencies:

```
  [864edb3b] ↑ DataStructures v0.18.22 ⇒ v0.19.1
  [2a0f44e3] - Base64 v1.11.0
  [b77e0a4c] - InteractiveUtils v1.11.0
  [ac6e5ff7] - JuliaSyntaxHighlighting v1.12.0
  [d6f4376e] - Markdown v1.11.0
  [f489334b] - StyledStrings v1.11.0
```